### PR TITLE
fix : head/TitleName

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -15,11 +15,23 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 export default {
   data() {
     return {
       title: 'GW 2020 Hackathon',
       color: 'info'
+    }
+  },
+  computed: {
+    ...mapGetters({
+      room: 'getRoom'
+    })
+  },
+  head() {
+    const title = this.room ? this.room.name : 'GW 2020 Hackathon'
+    return {
+      title
     }
   }
 }


### PR DESCRIPTION
headerタイトルをルームにはいっている際はルーム名を表示する様にした．
デフォルトはGW 2020 Hackathon